### PR TITLE
Settings: skip Misc/Overcounted battery stats in builds

### DIFF
--- a/src/com/android/settings/fuelgauge/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageSummary.java
@@ -319,7 +319,7 @@ public class PowerUsageSummary extends PowerUsageBase {
                     if (percentOfTotal < 10) {
                         continue;
                     }
-                    if ("user".equals(Build.TYPE)) {
+                    if ("user".equals(Build.TYPE) || "userdebug".equals(Build.TYPE)) {
                         continue;
                     }
                 }
@@ -332,7 +332,7 @@ public class PowerUsageSummary extends PowerUsageBase {
                     if (percentOfTotal < 5) {
                         continue;
                     }
-                    if ("user".equals(Build.TYPE)) {
+                    if ("user".equals(Build.TYPE) || "userdebug".equals(Build.TYPE)) {
                         continue;
                     }
                 }


### PR DESCRIPTION
Quadruple battery lifez.

Change-Id: I6f829dd62c8820a38f2ac1301e0fdc345852d1d3
Signed-off-by: Joey Rizzoli <joey@cyanogenmoditalia.it>